### PR TITLE
Fix react children only error

### DIFF
--- a/dev.log
+++ b/dev.log
@@ -1,0 +1,23 @@
+
+> khushbuwaala@0.1.0 dev
+> next dev --turbopack
+
+   ▲ Next.js 15.4.4 (Turbopack)
+   - Local:        http://localhost:3000
+   - Network:      http://172.30.0.2:3000
+   - Experiments (use with caution):
+     · optimizePackageImports
+
+ ✓ Starting...
+ ✓ Ready in 826ms
+ ○ Compiling /for-women ...
+ ✓ Compiled /for-women in 3s
+ ⨯ [Error: React.Children.only expected to receive a single React element child.] {
+  digest: '19471802'
+}
+ ⚠ metadataBase property in metadata export is not set for resolving social open graph or twitter images, using "http://localhost:3000". See https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase
+ ⨯ [Error: React.Children.only expected to receive a single React element child.] {
+  digest: '4124659065'
+}
+ GET /for-women 500 in 3925ms
+[?25h

--- a/src/components/Modules/Home/BannerSection.tsx
+++ b/src/components/Modules/Home/BannerSection.tsx
@@ -272,8 +272,10 @@ export function BannerSection({
               hapticFeedback
             >
               <Link href={link}>
-                <span className="relative z-10">{buttonText}</span>
-                <ArrowRight className="h-5 w-5 ml-2 transition-transform duration-300 group-hover/button:translate-x-1" />
+                <div className="flex items-center">
+                  <span className="relative z-10">{buttonText}</span>
+                  <ArrowRight className="h-5 w-5 ml-2 transition-transform duration-300 group-hover/button:translate-x-1" />
+                </div>
               </Link>
             </Button>
 

--- a/src/components/Modules/Home/CaoruselSlider.tsx
+++ b/src/components/Modules/Home/CaoruselSlider.tsx
@@ -68,7 +68,9 @@ export function CarouselSlider() {
                       className="px-8 py-3 bg-gradient-to-r from-red-600 to-pink-600 text-white font-semibold transition-all duration-300 ease-in-out hover:scale-105 hover:from-red-700 hover:to-pink-700 rounded-full shadow-lg animate-in fade-in zoom-in-95 duration-700 delay-300"
                     >
                       <Link href={slide.buttonLink} aria-label={slide.buttonText}>
-                        {slide.buttonText} <ArrowRight className="ml-2 h-4 w-4" />
+                        <div className="flex items-center">
+                          {slide.buttonText} <ArrowRight className="ml-2 h-4 w-4" />
+                        </div>
                       </Link>
                     </Button>
                   )}

--- a/src/components/Modules/Home/CategoryBanner.tsx
+++ b/src/components/Modules/Home/CategoryBanner.tsx
@@ -39,7 +39,9 @@ function CategoryCard({ CategoryName, CategoryImage, CategoryLink, description }
             className="w-fit px-6 py-2 bg-white text-red-600 font-semibold rounded-full shadow-md opacity-0 group-hover:opacity-100 transition-all duration-300 transform group-hover:scale-105"
           >
             <Link href={CategoryLink}>
-              Shop Now <ArrowRight className="ml-2 h-4 w-4" />
+              <div className="flex items-center">
+                Shop Now <ArrowRight className="ml-2 h-4 w-4" />
+              </div>
             </Link>
           </Button>
         </div>

--- a/src/components/Modules/Shop/ShopBanner.tsx
+++ b/src/components/Modules/Shop/ShopBanner.tsx
@@ -190,22 +190,24 @@ export function ShopBanner({
             className={`group relative px-12 py-6 text-lg font-bold transition-all duration-500 ease-out hover:scale-110 hover:shadow-2xl rounded-2xl ${styles.buttonStyle} border border-white/20 backdrop-blur-md ${styles.glowColor} overflow-hidden`}
           >
             <Link href={link} aria-label={`Shop now for ${heading}`}>
-              {/* Button content */}
-              <span className="relative z-10 flex items-center">
-                {buttonText}
-                <ArrowRight className="ml-3 h-6 w-6 transition-transform duration-300 group-hover:translate-x-3" />
-              </span>
+              <div className="relative w-full h-full">
+                {/* Button content */}
+                <span className="relative z-10 flex items-center">
+                  {buttonText}
+                  <ArrowRight className="ml-3 h-6 w-6 transition-transform duration-300 group-hover:translate-x-3" />
+                </span>
 
-              {/* Enhanced button effects */}
-              <div
-                className={`absolute inset-0 rounded-2xl bg-gradient-to-r ${styles.accent} opacity-0 group-hover:opacity-40 transition-opacity duration-500 blur-xl`}
-              ></div>
-              <div
-                className={`absolute inset-0 rounded-2xl bg-gradient-to-r ${styles.accent} opacity-0 group-hover:opacity-20 transition-opacity duration-500`}
-              ></div>
+                {/* Enhanced button effects */}
+                <div
+                  className={`absolute inset-0 rounded-2xl bg-gradient-to-r ${styles.accent} opacity-0 group-hover:opacity-40 transition-opacity duration-500 blur-xl`}
+                ></div>
+                <div
+                  className={`absolute inset-0 rounded-2xl bg-gradient-to-r ${styles.accent} opacity-0 group-hover:opacity-20 transition-opacity duration-500`}
+                ></div>
 
-              {/* Shimmer effect */}
-              <div className="absolute inset-0 -translate-x-full group-hover:translate-x-full transition-transform duration-1000 bg-gradient-to-r from-transparent via-white/20 to-transparent skew-x-12"></div>
+                {/* Shimmer effect */}
+                <div className="absolute inset-0 -translate-x-full group-hover:translate-x-full transition-transform duration-1000 bg-gradient-to-r from-transparent via-white/20 to-transparent skew-x-12"></div>
+              </div>
             </Link>
           </Button>
         </div>

--- a/src/components/Shared/FooterCollapsible.tsx
+++ b/src/components/Shared/FooterCollapsible.tsx
@@ -40,12 +40,14 @@ export default function FooterCollapsible ({ section }: FooterCollapsibleProps) 
           aria-expanded={isOpen}
           aria-controls={`${section.id}-content`}
         >
-          <div className="flex flex-col items-start">
-            <h3 className="text-lg font-semibold text-gray-900 mb-2">{section.title}</h3>
-            <div className={`h-0.5 ${section.underlineWidth} bg-gradient-to-r from-red-500 to-red-600 rounded-full`} />
-          </div>
-          <div className="transition-transform duration-300 group-data-[state=open]:rotate-180">
-            {isOpen ? <Minus className="h-5 w-5 text-gray-500" /> : <Plus className="h-5 w-5 text-gray-500" />}
+          <div className="flex items-start justify-between w-full">
+            <div className="flex flex-col items-start">
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">{section.title}</h3>
+              <div className={`h-0.5 ${section.underlineWidth} bg-gradient-to-r from-red-500 to-red-600 rounded-full`} />
+            </div>
+            <div className="transition-transform duration-300 group-data-[state=open]:rotate-180">
+              {isOpen ? <Minus className="h-5 w-5 text-gray-500" /> : <Plus className="h-5 w-5 text-gray-500" />}
+            </div>
           </div>
         </Button>
       </CollapsibleTrigger>

--- a/src/components/Shared/NavDrawer.tsx
+++ b/src/components/Shared/NavDrawer.tsx
@@ -163,30 +163,32 @@ export default function NavDrawer({ open, onClose }: NavDrawerProps) {
                           className="w-full justify-between h-14 px-4 text-left font-medium hover:bg-gradient-to-r hover:from-red-50 hover:to-pink-50 hover:text-red-600 transition-all duration-300 rounded-xl group"
                           aria-expanded={openSubmenu === item.key}
                         >
-                          <div className="flex items-center space-x-4">
-                            <div className="p-2 rounded-lg bg-gray-100 group-hover:bg-red-100 transition-colors duration-300">
-                              {item.icon}
+                          <div className="flex items-center justify-between w-full">
+                            <div className="flex items-center space-x-4">
+                              <div className="p-2 rounded-lg bg-gray-100 group-hover:bg-red-100 transition-colors duration-300">
+                                {item.icon}
+                              </div>
+                              <div className="flex flex-col items-start">
+                                <span className="font-semibold">{item.label}</span>
+                                {item.description && (
+                                  <span className="text-xs text-gray-500 group-hover:text-red-500">
+                                    {item.description}
+                                  </span>
+                                )}
+                              </div>
                             </div>
-                            <div className="flex flex-col items-start">
-                              <span className="font-semibold">{item.label}</span>
-                              {item.description && (
-                                <span className="text-xs text-gray-500 group-hover:text-red-500">
-                                  {item.description}
-                                </span>
+                            <div className="flex items-center space-x-2">
+                              {item.badge && (
+                                <Badge variant="secondary" className="text-xs bg-red-100 text-red-700">
+                                  {item.badge}
+                                </Badge>
                               )}
+                              <ChevronRight
+                                className={`h-4 w-4 transition-transform duration-300 ${
+                                  openSubmenu === item.key ? "rotate-90" : ""
+                                }`}
+                              />
                             </div>
-                          </div>
-                          <div className="flex items-center space-x-2">
-                            {item.badge && (
-                              <Badge variant="secondary" className="text-xs bg-red-100 text-red-700">
-                                {item.badge}
-                              </Badge>
-                            )}
-                            <ChevronRight
-                              className={`h-4 w-4 transition-transform duration-300 ${
-                                openSubmenu === item.key ? "rotate-90" : ""
-                              }`}
-                            />
                           </div>
                         </Button>
                       </CollapsibleTrigger>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -97,10 +97,10 @@ function Button({
       {...props}
     >
       {loading ? (
-        <>
+        <div className="flex items-center gap-2">
           <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-current" />
           <span className="opacity-70">Loading...</span>
-        </>
+        </div>
       ) : (
         children
       )}


### PR DESCRIPTION
Fixes "React.Children.only" error by ensuring Radix UI components with `asChild` always receive a single React element child.

This error commonly arises when Radix UI components, utilizing the `asChild` prop, internally invoke `React.Children.only()`, which strictly requires a single React element. The changes involve wrapping multiple JSX elements (like text alongside an icon, or a spinner with text) into a single container `div` to meet this expectation, resolving the issue in several UI components.

---
<a href="https://cursor.com/background-agent?bcId=bc-96898a6e-7878-469c-aabf-1ac42f2d3c80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-96898a6e-7878-469c-aabf-1ac42f2d3c80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>